### PR TITLE
Suggestion: Update code to work with oTree v5

### DIFF
--- a/P2021/Biases_T1/models.py
+++ b/P2021/Biases_T1/models.py
@@ -25,23 +25,27 @@ Treatment 1 for biases Decoy, Anchoring, Framing, Mental Accounting and Conjunct
 class Constants(BaseConstants):
     name_in_url = 'Biases_T1'
     players_per_group = None
-    num_rounds = 1
+    task_sequences = [
+        ['Decoy', 'Anchoring', 'Framing', 'MentalAccounting'],
+        ['MentalAccounting', 'Framing', 'Anchoring', 'Decoy'],
+        ['Framing', 'Anchoring', 'Decoy', 'MentalAccounting']
+    ]
+    num_rounds = 5  # length of task_sequences + 1 for Conjunction Fallacy
+
 
 # ******************************************************************************************************************** #
 # *** CLASS SUBSESSION *** #
 # ******************************************************************************************************************** #
 class Subsession(BaseSubsession):
     def creating_session(self):
-        from .pages import initial_page_sequence
-        ini = [i.__name__ for i in initial_page_sequence]
-        for p in self.get_players():
-            pb = ini.copy()
-            random.shuffle(pb)
-            p.page_sequence_t1 = json.dumps(random.choice([['Decoy','Anchoring','Framing','MentalAccounting','ConjunctionFallacy'],
-                                                       ['MentalAccounting','Framing','Anchoring','Decoy','ConjunctionFallacy'],
-                                                        ['Framing','Anchoring','Decoy','MentalAccounting','ConjunctionFallacy']]))
-            p.participant.vars["page_count"] = 1
-            p.participant.vars["task_sequence"] = p.page_sequence_t1
+        if self.round_number == 1:
+            for p in self.get_players():
+                round_numbers = list(range(1, Constants.num_rounds+1))
+                task_sequence = random.choice(Constants.task_sequences) + ['ConjunctionFallacy']
+                p.participant.vars["page_count"] = 1
+                p.participant.vars["page_sequence"] = dict(zip(task_sequence, round_numbers))
+                p.participant.vars["task_sequence"] = task_sequence
+                p.page_sequence_t1 = json.dumps(task_sequence)
 
 
 

--- a/P2021/Biases_T1/pages.py
+++ b/P2021/Biases_T1/pages.py
@@ -14,6 +14,8 @@ class Decoy(Page):
 
     def before_next_page(self):
         self.participant.vars["page_count"] += 1
+        if self.round_number != 1:
+            self.player.in_round(1).decoy_t1 = self.player.decoy_t1
 
     # form model and form fields
     # ----------------------------------------------------------------------------------------------------------------
@@ -49,9 +51,11 @@ class Decoy(Page):
 class Anchoring(Page):
     def is_displayed(self):
         return self.round_number == self.participant.vars['page_sequence']['Anchoring']
-    
+
     def before_next_page(self):
         self.participant.vars["page_count"] += 1
+        if self.round_number != 1:
+            self.player.in_round(1).anchoring_t1_wtp = self.player.anchoring_t1_wtp
 
     # form model and form fields
     # ----------------------------------------------------------------------------------------------------------------
@@ -87,9 +91,11 @@ class Anchoring(Page):
 class Framing(Page):
     def is_displayed(self):
         return self.round_number == self.participant.vars['page_sequence']['Framing']
-    
+
     def before_next_page(self):
         self.participant.vars["page_count"] += 1
+        if self.round_number != 1:
+            self.player.in_round(1).framing_t1 = self.player.framing_t1
 
     # form model and form fields
     # ----------------------------------------------------------------------------------------------------------------
@@ -126,6 +132,8 @@ class MentalAccounting(Page):
     
     def before_next_page(self):
         self.participant.vars["page_count"] += 1
+        if self.round_number != 1:
+            self.player.in_round(1).mental_accounting_t1 = self.player.mental_accounting_t1
 
     # form model and form fields
     # ----------------------------------------------------------------------------------------------------------------
@@ -161,6 +169,8 @@ class ConjunctionFallacy(Page):
 
     def before_next_page(self):
         self.participant.vars["page_count"] = 1
+        if self.round_number != 1:
+            self.player.in_round(1).conjunction_fallacy = self.player.conjunction_fallacy
 
     # form model and form fields
     # ----------------------------------------------------------------------------------------------------------------

--- a/P2021/Biases_T1/pages.py
+++ b/P2021/Biases_T1/pages.py
@@ -9,6 +9,9 @@ import json
 # *** PAGE DECOY *** #
 # ******************************************************************************************************************** #
 class Decoy(Page):
+    def is_displayed(self):
+        return self.round_number == self.participant.vars['page_sequence']['Decoy']
+
     def before_next_page(self):
         self.participant.vars["page_count"] += 1
 
@@ -44,6 +47,9 @@ class Decoy(Page):
 # *** PAGE ANCHORING *** #
 # ******************************************************************************************************************** #
 class Anchoring(Page):
+    def is_displayed(self):
+        return self.round_number == self.participant.vars['page_sequence']['Anchoring']
+    
     def before_next_page(self):
         self.participant.vars["page_count"] += 1
 
@@ -79,6 +85,9 @@ class Anchoring(Page):
 # *** PAGE FRAMING *** #
 # ******************************************************************************************************************** #
 class Framing(Page):
+    def is_displayed(self):
+        return self.round_number == self.participant.vars['page_sequence']['Framing']
+    
     def before_next_page(self):
         self.participant.vars["page_count"] += 1
 
@@ -112,6 +121,9 @@ class Framing(Page):
 # *** PAGE MENTAL ACCOUNTING *** #
 # ******************************************************************************************************************** #
 class MentalAccounting(Page):
+    def is_displayed(self):
+        return self.round_number == self.participant.vars['page_sequence']['MentalAccounting']
+    
     def before_next_page(self):
         self.participant.vars["page_count"] += 1
 
@@ -144,6 +156,9 @@ class MentalAccounting(Page):
 # *** PAGE CONJUNCTION FALLACY *** #
 # ******************************************************************************************************************** #
 class ConjunctionFallacy(Page):
+    def is_displayed(self):
+        return self.round_number == 5  # always shown last
+
     def before_next_page(self):
         self.participant.vars["page_count"] = 1
 
@@ -173,32 +188,10 @@ class ConjunctionFallacy(Page):
         }
 
 
-initial_page_sequence = [
+page_sequence = [
     Decoy,
     Anchoring,
     Framing,
     MentalAccounting,
     ConjunctionFallacy
 ]
-
-#compute page sequence
-page_sequence = [
-
-]
-
-
-class MyPage(Page):
-    def inner_dispatch(self):
-        page_seq = int(self.__class__.__name__.split('_')[1])
-        page_to_show = json.loads(self.player.page_sequence_t1)[page_seq]
-        self._is_frozen = False
-        self.__class__ = globals()[page_to_show]
-        return super(globals()[page_to_show], self).inner_dispatch()
-
-
-for i, _ in enumerate(initial_page_sequence):
-    NewClassName = "Page_{}".format(i)
-    A = type(NewClassName, (MyPage,), {})
-    locals()[NewClassName] = A
-    page_sequence.append(locals()[NewClassName])
-

--- a/P2021/Biases_T1/tests.py
+++ b/P2021/Biases_T1/tests.py
@@ -7,34 +7,34 @@ from .models import Constants
 
 class PlayerBot(Bot):
     def play_round(self):
-        if self.participant.vars["task_sequence"][:3] == """["D""":
-            # ------------------------------------------------------------------------------------------------------------ #
-            # make decisions
-            # ------------------------------------------------------------------------------------------------------------ #
-            yield (pages.Page_0, {'decoy_t1': random.choice(['C', 'T'])}) #Decoy
-            yield (pages.Page_1, {'anchoring_t1_wtp': random.randint(0,100)}) #Anchoring
-            yield (pages.Page_2, {'framing_t1': random.choice(['A','B'])}) #Framing
-            yield (pages.Page_3, {'mental_accounting_t1': random.randint(0,1)}) # MA
-            yield (pages.Page_4, {'conjunction_fallacy': random.randint(0,1)})# CJ
+        decoy_valid = {'decoy_t1': random.choice(['C', 'T'])}
+        anchoring_valid = {'anchoring_t1_wtp': random.randint(0, 100)}
+        framing_valid = {'framing_t1': random.choice(['A', 'B'])}
+        mental_valid = {'mental_accounting_t1': random.randint(0, 1)}
+        conjunction_valid = {'conjunction_fallacy': random.randint(0,1)}
 
-        elif self.participant.vars["task_sequence"][:3] == """["M""":
-            # ------------------------------------------------------------------------------------------------------------ #
-            # make decisions
-            # ------------------------------------------------------------------------------------------------------------ #
-            yield (pages.Page_0, {'mental_accounting_t1': random.randint(0,1)}) # MA
-            yield (pages.Page_1, {'framing_t1': random.choice(['A','B'])}) #Framing
-            yield (pages.Page_2, {'anchoring_t1_wtp': random.randint(0, 100)})  # Anchoring
-            yield (pages.Page_3, {'decoy_t1': random.choice(['C', 'D', 'T'])})  # Decoy
-            yield (pages.Page_4, {'conjunction_fallacy': random.randint(0,1)})# CJ
+        page_sequence = {
+            'Decoy': {
+                1: (pages.Decoy, decoy_valid),
+                2: (pages.Anchoring, anchoring_valid),
+                3: (pages.Framing, framing_valid),
+                4: (pages.MentalAccounting, mental_valid),
+                5: (pages.ConjunctionFallacy, conjunction_valid)
+            },
+            'MentalAccounting': {
+                1: (pages.MentalAccounting, mental_valid),
+                2: (pages.Framing, framing_valid),
+                3: (pages.Anchoring, anchoring_valid),
+                4: (pages.Decoy, decoy_valid),
+                5: (pages.ConjunctionFallacy, conjunction_valid)
+            },
+            'Framing': {
+                1: (pages.Framing, framing_valid),
+                2: (pages.Anchoring, anchoring_valid),
+                3: (pages.Decoy, decoy_valid),
+                4: (pages.MentalAccounting, mental_valid),
+                5: (pages.ConjunctionFallacy, conjunction_valid)
+            }
+        }
 
-        elif self.participant.vars["task_sequence"][:3] == """["F""":
-            # ------------------------------------------------------------------------------------------------------------ #
-            # make decisions
-            # ------------------------------------------------------------------------------------------------------------ #
-            yield (pages.Page_0, {'framing_t1': random.choice(['A','B'])}) #Framing
-            yield (pages.Page_1, {'anchoring_t1_wtp': random.randint(0, 100)})  # Anchoring
-            yield (pages.Page_2, {'decoy_t1': random.choice(['C', 'D', 'T'])})  # Decoy
-            yield (pages.Page_3, {'mental_accounting_t1': random.randint(0,1)}) # MA
-            yield (pages.Page_4, {'conjunction_fallacy': random.randint(0,1)})# CJ
-
-
+        yield page_sequence[self.participant.vars['task_sequence'][0]][self.round_number]

--- a/P2021/Biases_T2/models.py
+++ b/P2021/Biases_T2/models.py
@@ -25,19 +25,19 @@ Treatment 2 for biases Decoy, Anchoring, Framing, Mental Accounting and Conjunct
 class Constants(BaseConstants):
     name_in_url = 'Biases_T2'
     players_per_group = None
-    num_rounds = 1
+    num_rounds = 4  # one less than in T1, Conjunction Fallacy is missing.
 
 # ******************************************************************************************************************** #
 # *** CLASS SUBSESSION *** #
 # ******************************************************************************************************************** #
 class Subsession(BaseSubsession):
     def creating_session(self):
-        from .pages import initial_page_sequence
-        ini = [i.__name__ for i in initial_page_sequence]
-        for p in self.get_players():
-            pb = ini.copy()
-            random.shuffle(pb)
-            p.page_sequence_t2 = str(p.participant.vars["task_sequence"][:-23:]) + str(p.participant.vars["task_sequence"][-1:])#without conjunction fallacy
+        if self.round_number == 1:
+            for p in self.get_players():
+                round_numbers = list(range(1, Constants.num_rounds+1))
+                task_sequence = p.participant.vars["task_sequence"][:-1]  # without Conjunction Fallacy
+                p.participant.vars["page_sequence"] = dict(zip(task_sequence, round_numbers))
+                p.page_sequence_t2 = json.dumps(task_sequence)
 
 # ******************************************************************************************************************** #
 # *** CLASS GROUP *** #

--- a/P2021/Biases_T2/pages.py
+++ b/P2021/Biases_T2/pages.py
@@ -8,6 +8,9 @@ import json
 # *** PAGE DECOY *** #
 # ******************************************************************************************************************** #
 class Decoy(Page):
+    def is_displayed(self):
+        return self.round_number == self.participant.vars['page_sequence']['Decoy']
+    
     def before_next_page(self):
         self.participant.vars["page_count"] += 1
 
@@ -44,6 +47,9 @@ class Decoy(Page):
 # *** PAGE ANCHORING *** #
 # ******************************************************************************************************************** #
 class Anchoring(Page):
+    def is_displayed(self):
+        return self.round_number == self.participant.vars['page_sequence']['Anchoring']
+    
     def before_next_page(self):
         self.participant.vars["page_count"] += 1
 
@@ -81,6 +87,9 @@ class Anchoring(Page):
 # *** PAGE FRAMING *** #
 # ******************************************************************************************************************** #
 class Framing(Page):
+    def is_displayed(self):
+        return self.round_number == self.participant.vars['page_sequence']['Framing']
+    
     def before_next_page(self):
         self.participant.vars["page_count"] += 1
 
@@ -116,6 +125,9 @@ class Framing(Page):
 # *** PAGE MENTAL ACCOUNTING *** #
 # ******************************************************************************************************************** #
 class MentalAccounting(Page):
+    def is_displayed(self):
+        return self.round_number == self.participant.vars['page_sequence']['MentalAccounting']
+    
     def before_next_page(self):
         self.participant.vars["page_count"] += 1
 
@@ -148,29 +160,9 @@ class MentalAccounting(Page):
         }
 
 
-initial_page_sequence = [
+page_sequence = [
     Decoy,
     Anchoring,
     Framing,
     MentalAccounting,
 ]
-
-#compute page sequence
-page_sequence = [
-
-]
-
-class MyPage(Page):
-    def inner_dispatch(self):
-        page_seq = int(self.__class__.__name__.split('_')[1])
-        page_to_show = json.loads(self.player.page_sequence_t2)[page_seq]
-        self._is_frozen = False
-        self.__class__ = globals()[page_to_show]
-        return super(globals()[page_to_show], self).inner_dispatch()
-
-
-for i, _ in enumerate(initial_page_sequence):
-    NewClassName = "Page_{}".format(i)
-    A = type(NewClassName, (MyPage,), {})
-    locals()[NewClassName] = A
-    page_sequence.append(locals()[NewClassName])

--- a/P2021/Biases_T2/pages.py
+++ b/P2021/Biases_T2/pages.py
@@ -10,9 +10,11 @@ import json
 class Decoy(Page):
     def is_displayed(self):
         return self.round_number == self.participant.vars['page_sequence']['Decoy']
-    
+
     def before_next_page(self):
         self.participant.vars["page_count"] += 1
+        if self.round_number != 1:
+            self.player.in_round(1).decoy_t2 = self.player.decoy_t2
 
     # form model and form fields
     # ----------------------------------------------------------------------------------------------------------------
@@ -49,9 +51,12 @@ class Decoy(Page):
 class Anchoring(Page):
     def is_displayed(self):
         return self.round_number == self.participant.vars['page_sequence']['Anchoring']
-    
+
     def before_next_page(self):
         self.participant.vars["page_count"] += 1
+        if self.round_number != 1:
+            self.player.in_round(1).anchoring_t2_buy = self.player.anchoring_t2_buy
+            self.player.in_round(1).anchoring_t2_wtp = self.player.anchoring_t2_wtp
 
     # form model and form fields
     # ----------------------------------------------------------------------------------------------------------------
@@ -89,9 +94,11 @@ class Anchoring(Page):
 class Framing(Page):
     def is_displayed(self):
         return self.round_number == self.participant.vars['page_sequence']['Framing']
-    
+
     def before_next_page(self):
         self.participant.vars["page_count"] += 1
+        if self.round_number != 1:
+            self.player.in_round(1).framing_t2 = self.player.framing_t2
 
     # form model and form fields
     # ----------------------------------------------------------------------------------------------------------------
@@ -127,9 +134,11 @@ class Framing(Page):
 class MentalAccounting(Page):
     def is_displayed(self):
         return self.round_number == self.participant.vars['page_sequence']['MentalAccounting']
-    
+
     def before_next_page(self):
         self.participant.vars["page_count"] += 1
+        if self.round_number != 1:
+            self.player.in_round(1).mental_accounting_t2 = self.player.mental_accounting_t2
 
     # form model and form fields
     # ----------------------------------------------------------------------------------------------------------------

--- a/P2021/Biases_T2/tests.py
+++ b/P2021/Biases_T2/tests.py
@@ -7,39 +7,33 @@ import random
 
 class PlayerBot(Bot):
     def play_round(self):
-        if self.participant.vars["task_sequence"][:3] == """["D""": # Sequence starting with Decoy
-            # ------------------------------------------------------------------------------------------------------------ #
-            # make decisions
-            # ------------------------------------------------------------------------------------------------------------ #
-            yield (pages.Page_0, {'decoy_t2': random.choice(['C', 'D', 'T'])}) #Decoy
-            yield (pages.Page_1, random.choice(({"anchoring_t2_buy" : 0,
-                                                 'anchoring_t2_wtp': random.randint(0,75)},
-                                                {"anchoring_t2_buy" :1,
-                                                 'anchoring_t2_wtp': random.randint(76,100)}))) #Anchoring
-            yield (pages.Page_2, {'framing_t2': random.choice(['A','B'])}) # Framing
-            yield (pages.Page_3, {'mental_accounting_t2': random.randint(0,1)}) # MA
+        decoy_valid = {'decoy_t2': random.choice(['C', 'D', 'T'])}
+        anchoring_valid = random.choice((
+            {"anchoring_t2_buy": 0, 'anchoring_t2_wtp': random.randint(0, 75)},
+            {"anchoring_t2_buy": 1, 'anchoring_t2_wtp': random.randint(76, 100)}
+        ))
+        framing_valid = {'framing_t2': random.choice(['A', 'B'])}
+        mental_valid = {'mental_accounting_t2': random.randint(0, 1)}
 
-        elif self.participant.vars["task_sequence"][:3] == """["M""": # Sequence starting with Mental Accounting
-            # ------------------------------------------------------------------------------------------------------------ #
-            # make decisions
-            # ------------------------------------------------------------------------------------------------------------ #
-            yield (pages.Page_0, {'mental_accounting_t2': random.randint(0,1)}) # MA
-            yield (pages.Page_1, {'framing_t2': random.choice(['A','B'])}) # Framing
-            yield (pages.Page_2, random.choice(({"anchoring_t2_buy":0,
-                                                 'anchoring_t2_wtp': random.randint(0, 75)},
-                                                {"anchoring_t2_buy": 1,
-                                                 'anchoring_t2_wtp': random.randint(76, 100)}))) # Anchoring
-            yield (pages.Page_3, {'decoy_t2': random.choice(['C', 'D', 'T'])})  # Decoy
+        page_sequence = {
+            'Decoy': {
+                1: (pages.Decoy, decoy_valid),
+                2: (pages.Anchoring, anchoring_valid),
+                3: (pages.Framing, framing_valid),
+                4: (pages.MentalAccounting, mental_valid)
+            },
+            'MentalAccounting': {
+                1: (pages.MentalAccounting, mental_valid),
+                2: (pages.Framing, framing_valid),
+                3: (pages.Anchoring, anchoring_valid),
+                4: (pages.Decoy, decoy_valid)
+            },
+            'Framing': {
+                1: (pages.Framing, framing_valid),
+                2: (pages.Anchoring, anchoring_valid),
+                3: (pages.Decoy, decoy_valid),
+                4: (pages.MentalAccounting, mental_valid),
+            }
+        }
 
-        elif self.participant.vars["task_sequence"][:3] == """["F""": # Sequence starting with Framing
-            # ------------------------------------------------------------------------------------------------------------ #
-            # make decisions
-            # ------------------------------------------------------------------------------------------------------------ #
-            yield (pages.Page_0, {'framing_t2': random.choice(['A','B'])}) #Framing
-            yield (pages.Page_1, random.choice(({"anchoring_t2_buy": 0,
-                                                 'anchoring_t2_wtp': random.randint(0, 75)},
-                                                {"anchoring_t2_buy": 1,
-                                                 'anchoring_t2_wtp': random.randint(76, 100)}))) # Anchoring
-            yield (pages.Page_2, {'decoy_t2': random.choice(['C', 'D', 'T'])})  # Decoy
-            yield (pages.Page_3, {'mental_accounting_t2': random.randint(0,1)}) # MA
-
+        yield page_sequence[self.participant.vars['task_sequence'][0]][self.round_number]

--- a/P2021/requirements.txt
+++ b/P2021/requirements.txt
@@ -1,5 +1,2 @@
-# oTree-may-overwrite-this-file
-# IF YOU MODIFY THIS FILE, remove this comment.
-# otherwise, oTree will automatically overwrite it.
-otree>=3.2.3
-psycopg2>=2.8.4
+otree>=5.0.7
+psycopg2-binary>=2.8.4

--- a/P2021/requirements.txt
+++ b/P2021/requirements.txt
@@ -1,2 +1,3 @@
 otree>=5.0.7
 psycopg2-binary>=2.8.4
+requests

--- a/P2021/requirements_base.txt
+++ b/P2021/requirements_base.txt
@@ -1,2 +1,0 @@
-# You should put your requirements in requirements.txt instead.
-# You can delete this file.


### PR DESCRIPTION
I have made some changes to the way page order is randomized so that the experiment now works with oTree v5.
I highly suggest incorporating these changes and switch to oTree 5, because deployment will be easier and require fewer resources. In particular, you won't need a redis database and fewer / smaller dynos on Heroku. You might even get away without Postgres, saving even more money. (Check Chris' comment on using Postgres with oTree 5: https://otree.readthedocs.io/en/latest/server/ubuntu.html#database-postgres)

Page order randomization now relies on oTree's rounds feature. However, to avoid having the data spread out across 5 rounds depending on page order, the code now pulls the data from all pages (or rather rounds) into the dataset entry for round 1. That is, you can safely disregard data stored for rounds 2-5 (or 2-4 in T2) when conducting your analysis, as it is copied over to the respective variables of round 1.

Finally I fixed the tests for T1 and T2.